### PR TITLE
Update for PSPDFKit 8.3.0 for iOS and Xcode 10.2

### DIFF
--- a/PSPDFKit-Titanium.xcodeproj/project.pbxproj
+++ b/PSPDFKit-Titanium.xcodeproj/project.pbxproj
@@ -388,7 +388,7 @@
 					"$(TITANIUM_BASE_SDK)/**",
 					"$(TITANIUM_BASE_SDK2)/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-fobjc-arc-exceptions";
 				SDKROOT = iphoneos;
@@ -450,7 +450,7 @@
 					"$(TITANIUM_BASE_SDK)/**",
 					"$(TITANIUM_BASE_SDK2)/**",
 				);
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				OTHER_LDFLAGS = "-fobjc-arc-exceptions";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ PSPDFKit - The Leading Mobile PDF Framework for iOS and Android.
 ```xml
 <ti:app xmlns:ti="http://ti.appcelerator.org">
   <ios>
-    <min-ios-ver>10.0</min-ios-ver>
+    <min-ios-ver>11.0</min-ios-ver>
   </ios>
   <modules>
     <module platform="iphone">com.pspdfkit</module>
@@ -27,7 +27,7 @@ PSPDFKit - The Leading Mobile PDF Framework for iOS and Android.
 </ti:app>
 ```
 
-Note: PSPDFKit 8 for iOS needs at least Xcode 10 or higher and supports iOS 10+.
+Note: PSPDFKit 8 for iOS needs at least Xcode 10.2 or higher and supports iOS 11+.
 
 ## Using the PSPDFKit module
 

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 8.2.3
+version: 8.3.0
 description: PSPDFKit Titanium Module
 author: PSPDFKit GmbH
 license: Commercial, see www.PSPDFKit.com
@@ -15,4 +15,4 @@ moduleid: com.pspdfkit
 guid: 3056f4e3-4ee6-4cf3-8417-1d8b8f95853c0
 platform: iphone
 minsdk: 8.0.0.GA
-architectures: i386 x86_64 armv7 arm64
+architectures: x86_64 arm64


### PR DESCRIPTION
⚠️ Merge after PSPDFKit 8.3.0 stable is out ⚠️ 

---

## What to test:

- [x] Build the module using CLI
- [x] Build the module using Xcode 10.2
- [x] Use the new module in a newly created sample app
- [x] Use the new module in an app which used an older version of PSPDFKit for iOS and Titanium SDK 8.0.0.GA