### PR TITLE
Update for 8.3.1.GA and PSPDFKit 9.2.2 for iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ PSPDFKit.framework
 PSPDFKitUI.framework
 
 metadata.json
+Podfile.lock

--- a/PSPDFKit-Titanium.xcodeproj/project.pbxproj
+++ b/PSPDFKit-Titanium.xcodeproj/project.pbxproj
@@ -21,7 +21,6 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		0805D4D08B88D29F383D8F78 /* Pods_pspdfkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 323782240C57D8111DCB068F /* Pods_pspdfkit.framework */; };
 		24DD6CF91134B3F500162E58 /* ComPspdfkitModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 24DD6CF71134B3F500162E58 /* ComPspdfkitModule.h */; };
 		24DD6CFA1134B3F500162E58 /* ComPspdfkitModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 24DD6CF81134B3F500162E58 /* ComPspdfkitModule.m */; };
 		24DE9E1111C5FE74003F90F6 /* ComPspdfkitModuleAssets.h in Headers */ = {isa = PBXBuildFile; fileRef = 24DE9E0F11C5FE74003F90F6 /* ComPspdfkitModuleAssets.h */; };
@@ -52,6 +51,7 @@
 		78ED7A58146F00FE002EE22C /* TIPSPDFViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 78ED7A56146F00FE002EE22C /* TIPSPDFViewController.m */; };
 		AA747D9F0F9514B9006C5449 /* ComPspdfkit_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = AA747D9E0F9514B9006C5449 /* ComPspdfkit_Prefix.pch */; };
 		AACBBE4A0F95108600F1A2B1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AACBBE490F95108600F1A2B1 /* Foundation.framework */; };
+		C707E28E31A68302ECB50731 /* Pods_pspdfkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 100ED7BC04DAC0B43D35009E /* Pods_pspdfkit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,12 +65,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		100ED7BC04DAC0B43D35009E /* Pods_pspdfkit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_pspdfkit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1205AF23E0B41CF5A2AF2B09 /* Pods-pspdfkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pspdfkit.release.xcconfig"; path = "Target Support Files/Pods-pspdfkit/Pods-pspdfkit.release.xcconfig"; sourceTree = "<group>"; };
 		24DD6CF71134B3F500162E58 /* ComPspdfkitModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ComPspdfkitModule.h; path = Classes/ComPspdfkitModule.h; sourceTree = "<group>"; };
 		24DD6CF81134B3F500162E58 /* ComPspdfkitModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ComPspdfkitModule.m; path = Classes/ComPspdfkitModule.m; sourceTree = "<group>"; };
 		24DD6D1B1134B66800162E58 /* titanium.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = titanium.xcconfig; sourceTree = "<group>"; };
 		24DE9E0F11C5FE74003F90F6 /* ComPspdfkitModuleAssets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ComPspdfkitModuleAssets.h; path = Classes/ComPspdfkitModuleAssets.h; sourceTree = "<group>"; };
 		24DE9E1011C5FE74003F90F6 /* ComPspdfkitModuleAssets.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ComPspdfkitModuleAssets.m; path = Classes/ComPspdfkitModuleAssets.m; sourceTree = "<group>"; };
-		323782240C57D8111DCB068F /* Pods_pspdfkit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_pspdfkit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3A66F3202212D11200F62CCE /* PSPDFKitUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PSPDFKitUI.framework; path = platform/PSPDFKitUI.framework; sourceTree = "<group>"; };
 		3A66F3212212D11200F62CCE /* PSPDFKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PSPDFKit.framework; path = platform/PSPDFKit.framework; sourceTree = "<group>"; };
 		782DDA141483CAB400E7EEFD /* ComPspdfkitViewProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ComPspdfkitViewProxy.h; path = Classes/ComPspdfkitViewProxy.h; sourceTree = "<group>"; };
@@ -99,11 +100,10 @@
 		78ED7A55146F00FE002EE22C /* TIPSPDFViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TIPSPDFViewController.h; path = Classes/TIPSPDFViewController.h; sourceTree = "<group>"; };
 		78ED7A56146F00FE002EE22C /* TIPSPDFViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TIPSPDFViewController.m; path = Classes/TIPSPDFViewController.m; sourceTree = "<group>"; };
 		78FB05B9177304060006CE08 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
-		928106D1B4349D3C0C3D87A9 /* Pods-pspdfkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pspdfkit.release.xcconfig"; path = "Target Support Files/Pods-pspdfkit/Pods-pspdfkit.release.xcconfig"; sourceTree = "<group>"; };
 		AA747D9E0F9514B9006C5449 /* ComPspdfkit_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ComPspdfkit_Prefix.pch; sourceTree = SOURCE_ROOT; };
 		AACBBE490F95108600F1A2B1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		D2AAC07E0554694100DB518D /* libComPspdfkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libComPspdfkit.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		EA4E59670471763CE634426B /* Pods-pspdfkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pspdfkit.debug.xcconfig"; path = "Target Support Files/Pods-pspdfkit/Pods-pspdfkit.debug.xcconfig"; sourceTree = "<group>"; };
+		E40CDFBBAB1E9CDFFFD72BA1 /* Pods-pspdfkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pspdfkit.debug.xcconfig"; path = "Target Support Files/Pods-pspdfkit/Pods-pspdfkit.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,7 +124,7 @@
 				7884212114830B1B00203926 /* CoreMedia.framework in Frameworks */,
 				7884211F14830B1600203926 /* UIKit.framework in Frameworks */,
 				AACBBE4A0F95108600F1A2B1 /* Foundation.framework in Frameworks */,
-				0805D4D08B88D29F383D8F78 /* Pods_pspdfkit.framework in Frameworks */,
+				C707E28E31A68302ECB50731 /* Pods_pspdfkit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -139,7 +139,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		0867D691FE84028FC02AAC07 /* pspdfkit */ = {
+		0867D691FE84028FC02AAC07 = {
 			isa = PBXGroup;
 			children = (
 				08FB77AEFE84172EC02AAC07 /* Classes */,
@@ -160,7 +160,7 @@
 				3A66F3212212D11200F62CCE /* PSPDFKit.framework */,
 				3A66F3202212D11200F62CCE /* PSPDFKitUI.framework */,
 				7884215214830D3700203926 /* System */,
-				323782240C57D8111DCB068F /* Pods_pspdfkit.framework */,
+				100ED7BC04DAC0B43D35009E /* Pods_pspdfkit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -222,8 +222,8 @@
 		EC0CF1EB9936AC4DF981C63A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				EA4E59670471763CE634426B /* Pods-pspdfkit.debug.xcconfig */,
-				928106D1B4349D3C0C3D87A9 /* Pods-pspdfkit.release.xcconfig */,
+				E40CDFBBAB1E9CDFFFD72BA1 /* Pods-pspdfkit.debug.xcconfig */,
+				1205AF23E0B41CF5A2AF2B09 /* Pods-pspdfkit.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -254,7 +254,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB921E08733DC00010E9CD /* Build configuration list for PBXNativeTarget "pspdfkit" */;
 			buildPhases = (
-				5F953EF747685B9199B5C0B9 /* [CP] Check Pods Manifest.lock */,
+				1462CD7A3119F9E90136CEF0 /* [CP] Check Pods Manifest.lock */,
 				D2AAC07A0554694100DB518D /* Headers */,
 				D2AAC07B0554694100DB518D /* Sources */,
 				D2AAC07C0554694100DB518D /* Frameworks */,
@@ -288,7 +288,7 @@
 				French,
 				German,
 			);
-			mainGroup = 0867D691FE84028FC02AAC07 /* pspdfkit */;
+			mainGroup = 0867D691FE84028FC02AAC07;
 			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -300,7 +300,7 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		5F953EF747685B9199B5C0B9 /* [CP] Check Pods Manifest.lock */ = {
+		1462CD7A3119F9E90136CEF0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (

--- a/PSPDFKit-Titanium.xcodeproj/project.pbxproj
+++ b/PSPDFKit-Titanium.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		24DD6CFA1134B3F500162E58 /* ComPspdfkitModule.m in Sources */ = {isa = PBXBuildFile; fileRef = 24DD6CF81134B3F500162E58 /* ComPspdfkitModule.m */; };
 		24DE9E1111C5FE74003F90F6 /* ComPspdfkitModuleAssets.h in Headers */ = {isa = PBXBuildFile; fileRef = 24DE9E0F11C5FE74003F90F6 /* ComPspdfkitModuleAssets.h */; };
 		24DE9E1211C5FE74003F90F6 /* ComPspdfkitModuleAssets.m in Sources */ = {isa = PBXBuildFile; fileRef = 24DE9E1011C5FE74003F90F6 /* ComPspdfkitModuleAssets.m */; };
+		5A4EA718C28150CB9899F8D9 /* Pods_pspdfkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 59023771EC31F146E87D7FE5 /* Pods_pspdfkit.framework */; };
 		782DDA161483CAB600E7EEFD /* ComPspdfkitViewProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 782DDA141483CAB400E7EEFD /* ComPspdfkitViewProxy.h */; };
 		782DDA171483CAB600E7EEFD /* ComPspdfkitViewProxy.m in Sources */ = {isa = PBXBuildFile; fileRef = 782DDA151483CAB400E7EEFD /* ComPspdfkitViewProxy.m */; };
 		782DDA1D1483CB6100E7EEFD /* ComPspdfkitView.h in Headers */ = {isa = PBXBuildFile; fileRef = 782DDA1B1483CB6100E7EEFD /* ComPspdfkitView.h */; };
@@ -51,7 +52,6 @@
 		78ED7A58146F00FE002EE22C /* TIPSPDFViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 78ED7A56146F00FE002EE22C /* TIPSPDFViewController.m */; };
 		AA747D9F0F9514B9006C5449 /* ComPspdfkit_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = AA747D9E0F9514B9006C5449 /* ComPspdfkit_Prefix.pch */; };
 		AACBBE4A0F95108600F1A2B1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AACBBE490F95108600F1A2B1 /* Foundation.framework */; };
-		C707E28E31A68302ECB50731 /* Pods_pspdfkit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 100ED7BC04DAC0B43D35009E /* Pods_pspdfkit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,8 +65,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		100ED7BC04DAC0B43D35009E /* Pods_pspdfkit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_pspdfkit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		1205AF23E0B41CF5A2AF2B09 /* Pods-pspdfkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pspdfkit.release.xcconfig"; path = "Target Support Files/Pods-pspdfkit/Pods-pspdfkit.release.xcconfig"; sourceTree = "<group>"; };
 		24DD6CF71134B3F500162E58 /* ComPspdfkitModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ComPspdfkitModule.h; path = Classes/ComPspdfkitModule.h; sourceTree = "<group>"; };
 		24DD6CF81134B3F500162E58 /* ComPspdfkitModule.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ComPspdfkitModule.m; path = Classes/ComPspdfkitModule.m; sourceTree = "<group>"; };
 		24DD6D1B1134B66800162E58 /* titanium.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = titanium.xcconfig; sourceTree = "<group>"; };
@@ -74,6 +72,8 @@
 		24DE9E1011C5FE74003F90F6 /* ComPspdfkitModuleAssets.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ComPspdfkitModuleAssets.m; path = Classes/ComPspdfkitModuleAssets.m; sourceTree = "<group>"; };
 		3A66F3202212D11200F62CCE /* PSPDFKitUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PSPDFKitUI.framework; path = platform/PSPDFKitUI.framework; sourceTree = "<group>"; };
 		3A66F3212212D11200F62CCE /* PSPDFKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PSPDFKit.framework; path = platform/PSPDFKit.framework; sourceTree = "<group>"; };
+		46F0855D8E47BC11253C7383 /* Pods-pspdfkit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pspdfkit.release.xcconfig"; path = "Target Support Files/Pods-pspdfkit/Pods-pspdfkit.release.xcconfig"; sourceTree = "<group>"; };
+		59023771EC31F146E87D7FE5 /* Pods_pspdfkit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_pspdfkit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		782DDA141483CAB400E7EEFD /* ComPspdfkitViewProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ComPspdfkitViewProxy.h; path = Classes/ComPspdfkitViewProxy.h; sourceTree = "<group>"; };
 		782DDA151483CAB400E7EEFD /* ComPspdfkitViewProxy.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ComPspdfkitViewProxy.m; path = Classes/ComPspdfkitViewProxy.m; sourceTree = "<group>"; };
 		782DDA1B1483CB6100E7EEFD /* ComPspdfkitView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ComPspdfkitView.h; path = Classes/ComPspdfkitView.h; sourceTree = "<group>"; };
@@ -101,9 +101,9 @@
 		78ED7A56146F00FE002EE22C /* TIPSPDFViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = TIPSPDFViewController.m; path = Classes/TIPSPDFViewController.m; sourceTree = "<group>"; };
 		78FB05B9177304060006CE08 /* libxml2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libxml2.dylib; path = usr/lib/libxml2.dylib; sourceTree = SDKROOT; };
 		AA747D9E0F9514B9006C5449 /* ComPspdfkit_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ComPspdfkit_Prefix.pch; sourceTree = SOURCE_ROOT; };
+		AA8F13DE8462AD24BFC2CE33 /* Pods-pspdfkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pspdfkit.debug.xcconfig"; path = "Target Support Files/Pods-pspdfkit/Pods-pspdfkit.debug.xcconfig"; sourceTree = "<group>"; };
 		AACBBE490F95108600F1A2B1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		D2AAC07E0554694100DB518D /* libComPspdfkit.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libComPspdfkit.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		E40CDFBBAB1E9CDFFFD72BA1 /* Pods-pspdfkit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-pspdfkit.debug.xcconfig"; path = "Target Support Files/Pods-pspdfkit/Pods-pspdfkit.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -124,7 +124,7 @@
 				7884212114830B1B00203926 /* CoreMedia.framework in Frameworks */,
 				7884211F14830B1600203926 /* UIKit.framework in Frameworks */,
 				AACBBE4A0F95108600F1A2B1 /* Foundation.framework in Frameworks */,
-				C707E28E31A68302ECB50731 /* Pods_pspdfkit.framework in Frameworks */,
+				5A4EA718C28150CB9899F8D9 /* Pods_pspdfkit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -139,7 +139,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		0867D691FE84028FC02AAC07 = {
+		0867D691FE84028FC02AAC07 /* pspdfkit */ = {
 			isa = PBXGroup;
 			children = (
 				08FB77AEFE84172EC02AAC07 /* Classes */,
@@ -160,7 +160,7 @@
 				3A66F3212212D11200F62CCE /* PSPDFKit.framework */,
 				3A66F3202212D11200F62CCE /* PSPDFKitUI.framework */,
 				7884215214830D3700203926 /* System */,
-				100ED7BC04DAC0B43D35009E /* Pods_pspdfkit.framework */,
+				59023771EC31F146E87D7FE5 /* Pods_pspdfkit.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -222,8 +222,8 @@
 		EC0CF1EB9936AC4DF981C63A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E40CDFBBAB1E9CDFFFD72BA1 /* Pods-pspdfkit.debug.xcconfig */,
-				1205AF23E0B41CF5A2AF2B09 /* Pods-pspdfkit.release.xcconfig */,
+				AA8F13DE8462AD24BFC2CE33 /* Pods-pspdfkit.debug.xcconfig */,
+				46F0855D8E47BC11253C7383 /* Pods-pspdfkit.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -254,7 +254,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB921E08733DC00010E9CD /* Build configuration list for PBXNativeTarget "pspdfkit" */;
 			buildPhases = (
-				1462CD7A3119F9E90136CEF0 /* [CP] Check Pods Manifest.lock */,
+				EC69B29CADA1E8C78818C53D /* [CP] Check Pods Manifest.lock */,
 				D2AAC07A0554694100DB518D /* Headers */,
 				D2AAC07B0554694100DB518D /* Sources */,
 				D2AAC07C0554694100DB518D /* Frameworks */,
@@ -288,7 +288,7 @@
 				French,
 				German,
 			);
-			mainGroup = 0867D691FE84028FC02AAC07;
+			mainGroup = 0867D691FE84028FC02AAC07 /* pspdfkit */;
 			productRefGroup = 034768DFFF38A50411DB9C8B /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -300,7 +300,24 @@
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		1462CD7A3119F9E90136CEF0 /* [CP] Check Pods Manifest.lock */ = {
+		84E7410B23D2219F00641E72 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Remove the outdated frameworks\nrm -rf ${SRCROOT}/platform/PSPDFKit.framework\nrm -rf ${SRCROOT}/platform/PSPDFKitUI.framework\n\n# Copy the frameworks\ncp -R ${SRCROOT}/Pods/PSPDFKit/PSPDFKit.framework ${SRCROOT}/platform/PSPDFKit.framework\ncp -R ${SRCROOT}/Pods/PSPDFKit/PSPDFKitUI.framework ${SRCROOT}/platform/PSPDFKitUI.framework\n";
+		};
+		EC69B29CADA1E8C78818C53D /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -321,23 +338,6 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
-		};
-		84E7410B23D2219F00641E72 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "cp -R ${SRCROOT}/Pods/PSPDFKit/PSPDFKit.framework ${SRCROOT}/platform/PSPDFKit.framework\ncp -R ${SRCROOT}/Pods/PSPDFKit/PSPDFKitUI.framework ${SRCROOT}/platform/PSPDFKitUI.framework\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@ PSPDFKit - The Leading Mobile PDF Framework for iOS and Android. PSPDFKit 9.2.2 
 
 ## Getting Started Step by Step Guide
 
-> **Note:** Read the [Alloy](#alloy) section before building the module if you're using the Alloy framework.
+> **Note:** Read the [Alloy](#alloy) section before building the module if you’re using the Alloy framework.
 
 This uses the Appcelerator CLI, not Appcelerator Studio, and assumes Xcode 11.3.1 is installed as default.
 
-#### Configuring the Environment
+### Configuring the Environment
 
-First, let's make sure we properly prepare our global environment.
+First, let’s make sure we properly prepare our global environment:
 
 ```bash
-# Make sure Xcode’s Command Line Tools are installed.
+# Make sure that the Xcode Command Line Tools are installed.
 $ sudo xcode-select --install
 
 # Also make sure we’ve accepted the Xcode EULA.
@@ -23,7 +23,7 @@ $ sudo xcodebuild -license
 $ gem install cocoapods
 ```
 
-Then, let's clone the plugin.
+Then, let’s clone the plugin:
 
 ```bash
 # Move to the workspace.
@@ -33,7 +33,7 @@ $ cd ~/path/to/workspace/
 $ git clone https://github.com/PSPDFKit/Appcelerator-iOS.git
 ```
 
-After that, let's install Appcelerator tools.
+After that, let’s install the Appcelerator tools:
 
 ```bash
 # Move to the plugin directory.
@@ -48,13 +48,13 @@ $ npm install appcelerator titanium
 # Run through the basic Appcelerator setup. Requires you to log in.
 $ appc setup
 
-# Install the latest appcelerator (if it doesn't exist already).
+# Install the latest appcelerator (if it isn’t already).
 $ appc use 7.1.2
 ```
 
 You can also run `appc use` to list all available versions for Appcelerator. If some of the following steps fail, please try with an older version of appcelerator, such as 7.0.12: `appc use 7.0.12`.
 
-#### Building the PSPDFKit Module
+### Building the PSPDFKit Module
 
 From inside the plugin directory, modify `Podfile` to include your CocoaPods key for PSPDFKit, which you can retrieve from the [Customer Portal](https://customers.pspdfkit.com/customers/sign_in):
 
@@ -85,7 +85,7 @@ Unzip the result into the Titanium folder:
 $ unzip ./dist/com.pspdfkit-iphone-9.2.2.zip -d ~/Library/Application\ Support/Titanium
 ```
 
-#### Using the PSPDFKit Plugin
+### Using the PSPDFKit Plugin
 
 Once we’ve installed the dependencies, and built the PSPDFKit plugin, we can now create a new app using the CLI:
 
@@ -132,7 +132,7 @@ Open `MyApp/Resources/app.js` and update your license key, which you can retriev
 **To run the application** from the CLI, manually launch a Simulator.app instance, and from the Hardware menu, select a device to launch (`Hardware Menu/Device/iOS 13.3/iPhone 8`, for instance). Then get the UUID for the simulator you’ve launched:
 
 ```bash
-# List the booted simulators
+# List the booted simulators.
 $ xcrun simctl list devices | grep Booted
     iPhone 8 (60FDA403-8D0B-40A4-BBE5-662C045A6A97) (Booted)
 ```
@@ -170,11 +170,11 @@ const pdfView = PSPDFKit.createView({
 
 ## Troubleshooting
 
-#### 'PSPDFKit.h' file not found
+### 'PSPDFKit.h' file not found
 
-If `PSPDFKit.h` can't be found you need to add the directory that contains `PSPDFKit.h` to the "Header Search Paths" build setting in the Xcode project (`PSPDFKit-Titanium.xcodeproj`). The correct directories are `$(SRCROOT)/PSPDFKit.framework/Headers` and `$(SRCROOT)/PSPDFKitUI.framework/Headers` (recursive).
+If `PSPDFKit.h` can’t be found you need to add the directory that contains `PSPDFKit.h` to the "Header Search Paths" build setting in the Xcode project (`PSPDFKit-Titanium.xcodeproj`). The correct directories are `$(SRCROOT)/PSPDFKit.framework/Headers` and `$(SRCROOT)/PSPDFKitUI.framework/Headers` (recursive).
 
-#### Build error
+### Build error
 
 ```bash
 [ERROR] :  ** BUILD FAILED **
@@ -183,7 +183,7 @@ If `PSPDFKit.h` can't be found you need to add the directory that contains `PSPD
 [ERROR] :  (1 failure)
 ```
 
-If you get the above build error when running the project, you likely forgot to include the PSPDFKit module in the `tiapp.xml`:
+If you get the above build error when running the project, it’s likely because the PSPDFKit module was not included in your project’s `tiapp.xml`:
 
 ```xml
   <modules>
@@ -191,16 +191,16 @@ If you get the above build error when running the project, you likely forgot to 
   </modules>
 ```
 
-#### Using the correct version of Titanium
+### Using the correct version of Titanium
 
-If you have multiple versions of the Titanium SDK installed on your system, you'll need to also modify the `titanium.xcconfig` configuration file to set the correct version number:
+If you have multiple versions of the Titanium SDK installed on your system, you’ll need to also modify the `titanium.xcconfig` configuration file to set the correct version number:
 
 ```diff
 - TITANIUM_SDK_VERSION = 8.3.0.GA
 + TITANIUM_SDK_VERSION = 8.3.1.GA
 ```
 
-#### Alloy
+### Alloy
 
 Alloy overwrites all files in the `Resources` folder everytime the application is built. This means you need to copy `PSPDFKit.framework` and `PSPDFKitUI.framework` into a different folder than the default `Resources/iphone`, for example `Frameworks`. You also need to do the following before building the module:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PSPDFKit for iOS Appcelerator Bindings
 
-PSPDFKit - The Leading Mobile PDF Framework for iOS and Android. PSPDFKit 9.2.2 for iOS needs at least Xcode 11.3.1 or higher and supports iOS 11 ([read more](https://pspdfkit.com/guides/ios/current/announcements/version-support/)). 
+PSPDFKit - The Leading Mobile PDF Framework for iOS and Android. PSPDFKit 9.2.2 for iOS needs at least Xcode 11.3.1 or higher and supports iOS 11 ([read more](https://pspdfkit.com/guides/ios/current/announcements/version-support/)).
 
 ## Getting Started Step by Step Guide
 
@@ -10,28 +10,45 @@ This uses the Appcelerator CLI, not Appcelerator Studio, and assumes Xcode 11.3.
 
 #### Configuring the Environment
 
-First, let’s make sure our dependencies are installed.
+First, let's make sure we properly prepare our global environment.
 
 ```bash
-# First, make sure we’re using Node 8.
-$ nvm use 8 -g			
+# Make sure Xcode’s Command Line Tools are installed.
+$ sudo xcode-select --install
 
-# Install Appcelerator CLI and Titanium 
-$ npm install appcelerator titanium -g
+# Also make sure we’ve accepted the Xcode EULA.
+$ sudo xcodebuild -license
 
 # Install CocoaPods.
 $ gem install cocoapods
+```
+
+Then, let's clone the plugin.
+
+```bash
+# Move to the workspace.
+$ cd ~/path/to/workspace/
+
+# Clone the PSPDFKit Appcelerator Plugin.
+$ git clone https://github.com/PSPDFKit/Appcelerator-iOS.git
+```
+
+After that, let's install Appcelerator tools.
+
+```bash
+# Move to the plugin directory.
+$ cd Appcelerator-iOS/
+
+# Make sure we’re using Node 8.
+$ nvm use 8
+
+# Install Appcelerator and Titanium CLIs.
+$ npm install appcelerator titanium
 
 # Run through the basic Appcelerator setup. Requires you to log in.
 $ appc setup
 
-# IMPORTANT: Make sure Xcode’s Command Line Tools are installed
-$ sudo xcode-select --install
-
-# IMPORTANT: Also make sure we’ve accepted the Xcode EULA
-$ sudo xcodebuild -license
-
-# Install the latest appcelerator
+# Install the latest appcelerator (if it doesn't exist already).
 $ appc use 7.1.2
 ```
 
@@ -39,17 +56,7 @@ You can also run `appc use` to list all available versions for Appcelerator. If 
 
 #### Building the PSPDFKit Module
 
-We can now procceed to build the plugin.
-
-```bash
-# Move to the workspace
-$ cd ~/path/to/workspace/
-
-# Clone the PSPDFKit Appcelerator Plugin
-$ git clone https://github.com/PSPDFKit/Appcelerator-iOS.git
-```
-
-Modify `Appcelerator-iOS/Podfile` to include your CocoaPods key for PSPDFKit, which you can retrieve from the [Customer Portal](https://customers.pspdfkit.com/customers/sign_in):
+From inside the plugin directory, modify `Podfile` to include your CocoaPods key for PSPDFKit, which you can retrieve from the [Customer Portal](https://customers.pspdfkit.com/customers/sign_in):
 
 ```diff
 platform :ios, '11.0'
@@ -65,18 +72,15 @@ end
 Once you’ve done that, you can now install the dependencies and builld the plugin:
 
 ```bash
-# Move to the plugin’s directory
-$ cd Appcelerator-iOS/
-
-# Download the PSPDFKit dependency
+# Download the PSPDFKit dependency.
 $ pod install
 
-# Build the Plugin
-$ ti build -p ios --build-only
+# Build the Plugin.
+$ ti build --platform ios --build-only
 ```
 
 Unzip the result into the Titanium folder:
- 
+
 ```bash
 $ unzip ./dist/com.pspdfkit-iphone-9.2.2.zip -d ~/Library/Application\ Support/Titanium
 ```
@@ -86,10 +90,10 @@ $ unzip ./dist/com.pspdfkit-iphone-9.2.2.zip -d ~/Library/Application\ Support/T
 Once we’ve installed the dependencies, and built the PSPDFKit plugin, we can now create a new app using the CLI:
 
 ```bash
-# Go to the root of the workspace
+# Go to the root of the workspace.
 $ cd ..
 
-# And create the new app
+# And create the new app.
 $ appc new --type app --name MyApp --id com.example.MyApp
 ```
 
@@ -109,10 +113,10 @@ Modify `MyApp/tiapp.xml` to include PSPDFKit as a module, and to define iOS 11 a
 And integrate the PSPDFKit example into the new application:
 
 ```bash
-# Rename the app folder to avoid using the Alloy framework for now
+# Rename the app folder to avoid using the Alloy framework for now.
 $ mv MyApp/app MyApp/__app
 
-# Copy the PSPDFKit example into place
+# Copy the PSPDFKit example into place.
 $ cp -R Appcelerator-iOS/example/ MyApp/Resources/
 ```
 
@@ -136,14 +140,14 @@ $ xcrun simctl list devices | grep Booted
 Copy the UUID for the device, then run the app on it:
 
 ```bash
-# Move to the app directory
+# Move to the app directory.
 $ cd MyApp
 
-# And run the app on the device
-$ appc run --platform ios -l trace --device-id 60FDA403-8D0B-40A4-BBE5-662C045A6A97
+# And run the app on the device.
+$ ti build --platform ios --device-id 60FDA403-8D0B-40A4-BBE5-662C045A6A97
 ```
 
-> The `-l trace` option is not required, but its useful to get more information should something go wrong with the installation.
+> Should something go wrong with the installation, prefix the command with `DEBUG=*` (like `DEBUG=* ti build...`) to enable verbose mode and get more information.
 
 ## Using the PSPDFKit Module
 
@@ -205,11 +209,11 @@ Alloy overwrites all files in the `Resources` folder everytime the application i
 
 ## License
 
-This project can be used for evaluation or if you have a valid PSPDFKit license.  
-All items and source code Copyright © 2010-2019 PSPDFKit GmbH.
+This project can be used for evaluation or if you have a valid PSPDFKit license.
+All items and source code Copyright © 2010-2020 PSPDFKit GmbH.
 
 See LICENSE for details.
 
 ## Contributing
-  
+
 Please ensure [you signed our CLA](https://pspdfkit.com/guides/web/current/miscellaneous/contributing/) so we can accept your contributions.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PSPDFKit for iOS Appcelerator Bindings
 
-PSPDFKit - The Leading Mobile PDF Framework for iOS and Android. PSPDFKit 9.2.1 for iOS needs at least Xcode 11.3.1 or higher and supports iOS 11 ([read more](https://pspdfkit.com/guides/ios/current/announcements/version-support/)). 
+PSPDFKit - The Leading Mobile PDF Framework for iOS and Android. PSPDFKit 9.2.2 for iOS needs at least Xcode 11.3.1 or higher and supports iOS 11 ([read more](https://pspdfkit.com/guides/ios/current/announcements/version-support/)). 
 
 ## Getting Started Step by Step Guide
 
@@ -78,7 +78,7 @@ $ ti build -p ios --build-only
 Unzip the result into the Titanium folder:
  
 ```bash
-$ unzip ./dist/com.pspdfkit-iphone-9.2.1.zip -d ~/Library/Application\ Support/Titanium
+$ unzip ./dist/com.pspdfkit-iphone-9.2.2.zip -d ~/Library/Application\ Support/Titanium
 ```
 
 #### Using the PSPDFKit Plugin
@@ -101,7 +101,7 @@ Modify `MyApp/tiapp.xml` to include PSPDFKit as a module, and to define iOS 11 a
 +   <min-ios-ver>11.0</min-ios-ver>
   </ios>
   <modules>
-+   <module version="9.2.1" platform="iphone">com.pspdfkit</module>
++   <module version="9.2.2" platform="iphone">com.pspdfkit</module>
   </modules>
 </ti:app>
 ```

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ If you get the above build error when running the project, you likely forgot to 
 If you have multiple versions of the Titanium SDK installed on your system, you'll need to also modify the `titanium.xcconfig` configuration file to set the correct version number:
 
 ```diff
-- TITANIUM_SDK_VERSION = 8.0.1.GA
-+ TITANIUM_SDK_VERSION = 8.3.0.GA
+- TITANIUM_SDK_VERSION = 8.3.0.GA
++ TITANIUM_SDK_VERSION = 8.3.1.GA
 ```
 
 #### Alloy

--- a/manifest
+++ b/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 9.2.1
+version: 9.2.2
 description: PSPDFKit Titanium Module
 author: PSPDFKit GmbH
 license: Commercial, see www.PSPDFKit.com
@@ -14,5 +14,5 @@ name: PSPDFKit
 moduleid: com.pspdfkit
 guid: 3056f4e3-4ee6-4cf3-8417-1d8b8f95853c0
 platform: iphone
-minsdk: 8.3.0.GA
+minsdk: 8.3.1.GA
 architectures: x86_64 arm64

--- a/titanium.xcconfig
+++ b/titanium.xcconfig
@@ -8,7 +8,7 @@
 #include "Pods/Target Support Files/Pods-pspdfkit/Pods-pspdfkit.debug.xcconfig"
 #include "Pods/Target Support Files/Pods-pspdfkit/Pods-pspdfkit.release.xcconfig"
 
-TITANIUM_SDK_VERSION = 8.3.0.GA
+TITANIUM_SDK_VERSION = 8.3.1.GA
 
 
 //


### PR DESCRIPTION
## What to test:

- [x] Build the module using CLI
- [x] Build the module using Xcode 11.3.1
- [x] Use the new module in a newly created sample app
- [x] Use the new module in an app which used an older version of PSPDFKit for iOS and Titanium SDK 8.3.1.GA