### PR TITLE
Update to PSPDFKit 10.2 for iOS 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
       # Choose Xcode version.
       - name: Choose Xcode version
-        run: sudo xcode-select -switch /Applications/Xcode_12.2.app
+        run: sudo xcode-select -switch /Applications/Xcode_12.4.app
       # Choose Node version.
       - name: Choose Node version
         uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **[PSPDFKit for iOS](https://pspdfkit.com/pdf-sdk/ios) — the best way to handle PDF documents on iOS.** A high-performance viewer, extensive annotation and document editing tools, digital signatures, and more. All engineered for the best possible user and developer experience.
 
-PSPDFKit for iOS Titanium module requires a valid license of PSPDFKit for iOS. You can [request a trial license here](https://pspdfkit.com/try). PSPDFKit 10.1.1 for iOS requires Xcode 12.2 or later and supports iOS 12 or later. Read more about version support [in our guides](https://pspdfkit.com/guides/ios/current/announcements/version-support). Check out [our changelog](https://pspdfkit.com/changelog/ios) to learn more about the releases.
+PSPDFKit for iOS Titanium module requires a valid license of PSPDFKit for iOS. You can [request a trial license here](https://pspdfkit.com/try). PSPDFKit 10.2 for iOS requires Xcode 12.4 or later and supports iOS 12 or later. Read more about version support [in our guides](https://pspdfkit.com/guides/ios/current/announcements/version-support). Check out [our changelog](https://pspdfkit.com/changelog/ios) to learn more about the releases.
 
 ## Support, Issues and License Questions
 

--- a/manifest
+++ b/manifest
@@ -9,8 +9,8 @@
 
 # The following values will be used by the build script.
 
-version: 10.1.2
-minsdk: 9.3.0.GA
+version: 10.2.0
+minsdk: 9.3.2.GA
 
 # Do not edit the below lines.
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
         "appcelerator": "^5.0.0",
         "chalk": "^4.1.0",
         "child-process-async": "^1.0.1",
-        "fs-extra": "^9.0.1",
+        "fs-extra": "^9.1.0",
         "lodash": "^4.17.20",
         "shell-escape": "^0.2.0",
         "titanium": "^5.3.0",
-        "yargs": "^15.4.1"
+        "yargs": "^16.2.0"
     }
 }


### PR DESCRIPTION
This PR updates the bridge to PSPDFKit 10.2 for iOS and Titanium SDK 9.3.2.GA. The npm packages used by the build script have also been updated to their latest versions.